### PR TITLE
remove conflict files

### DIFF
--- a/toybox/opkg/rules
+++ b/toybox/opkg/rules
@@ -14,6 +14,7 @@ case "$1" in
     rm -rf /tmp/$PACKAGE
     mkdir -p /tmp/$PACKAGE
     PREFIX=/tmp/$PACKAGE/bin make CC=clang install_flat
+    rm -rf /tmp/$PACKAGE/bin/{reset,clear}
     ;;
 
   clean)


### PR DESCRIPTION
```
Collected errors:
 * check_data_file_clashes: Package toybox wants to install file root//bin/reset
	But that file is already provided by package  * netbsd-curses
 * check_data_file_clashes: Package toybox wants to install file root//bin/clear
	But that file is already provided by package  * netbsd-curses
 * opkg_solver_install: Cannot install package toybox.
```